### PR TITLE
Add visual mapping for sexp swap commands

### DIFF
--- a/plugin/sexp_mappings_for_regular_people.vim
+++ b/plugin/sexp_mappings_for_regular_people.vim
@@ -52,6 +52,10 @@ function! s:sexp_mappings() abort
   nmap <buffer> <)  <Plug>(sexp_emit_tail_element)
   nmap <buffer> <(  <Plug>(sexp_capture_prev_element)
   nmap <buffer> >)  <Plug>(sexp_capture_next_element)
+  xmap <buffer> <f  <Plug>(sexp_swap_list_backward)
+  xmap <buffer> >f  <Plug>(sexp_swap_list_forward)
+  xmap <buffer> <e  <Plug>(sexp_swap_element_backward)
+  xmap <buffer> >e  <Plug>(sexp_swap_element_forward)
 endfunction
 
 function! s:setup() abort


### PR DESCRIPTION
Sexp allows swapping of visually selected elements/forms. 
It is very useful to move around pairs of elements like map entry or let binding.

https://github.com/guns/vim-sexp/blob/master/doc/vim-sexp.txt#L441-L455