### PR TITLE
Update installation documentation in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,10 +15,10 @@ You know the drill.  Here's a copy and paste to install the works with
 [pathogen.vim](https://github.com/tpope/vim-pathogen).
 
     cd ~/.vim/bundle
-    git clone git://github.com/tpope/vim-sexp-mappings-for-regular-people.git
-    git clone git://github.com/guns/vim-sexp.git
-    git clone git://github.com/tpope/vim-repeat.git
-    git clone git://github.com/tpope/vim-surround.git
+    git clone https://github.com/tpope/vim-sexp-mappings-for-regular-people.git
+    git clone https://github.com/guns/vim-sexp.git
+    git clone https://github.com/tpope/vim-repeat.git
+    git clone https://github.com/tpope/vim-surround.git
 
 ## Provided mappings
 


### PR DESCRIPTION
Current installation instruction does not work as the git clone commands fail.  This is because unencrypted git protocol support has been removed by github (see https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/).
The urls in the README have been updated to make use of the https protocol.